### PR TITLE
Ma feature

### DIFF
--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -1,0 +1,43 @@
+name: Auto-Bump Version
+
+on:
+  push:
+    branches: ["main"] # Se déclenche sur push vers main
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    # Skip si commit contient [skip-version]
+    if: '!contains(github.event.head_commit.message, "[skip-version]")'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }} # Utilise le PAT
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Update Package Version
+        run: |
+          # Incrémente la version PATCH (1.0.0 → 1.0.1)
+          npm version patch -m "Auto-bump to v%s [skip ci]"
+
+          # Configure Git pour le commit
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          # Pousse les changements
+          git push origin main
+        env:
+          # Autorise npm à faire des commits
+          GIT_AUTHOR_NAME: "github-actions"
+          GIT_AUTHOR_EMAIL: "actions@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions"
+          GIT_COMMITTER_EMAIL: "actions@users.noreply.github.com"

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -10,7 +10,7 @@ export const usePost = () => {
     const { setPosts,  setError } = usePostStore();
 
     const handleCreatePosts = useMutation({
-        mutationFn: (newPost: PostProps) => postService.createPost(newPost),
+        mutationFn: (newPost: Omit<PostProps, '_id'>) => postService.createPost(newPost),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['posts'] })
         }


### PR DESCRIPTION
Conflit resolved

## Summary by Sourcery

Update CI Node version to 22 and refine post creation hook to exclude the “_id” field

Enhancements:
- Bump Node version from 20 to 22 in the version-updater GitHub Action
- Change createPost mutation signature to accept new posts without the “_id” property