### PR TITLE
use service api in home page and add queryProvider

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import App from './App.tsx'
 import './index.css'
 import { BrowserRouter } from 'react-router-dom'
 import { registerServiceWorker } from './sw-register'
+import { QueryClientProvider } from '@tanstack/react-query'
+import queryClient from './utils/queryClient.ts'
 
 // Enregistrer le service worker
 registerServiceWorker()
@@ -11,7 +13,9 @@ registerServiceWorker()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-    <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,
 )

--- a/src/models/PostProps.ts
+++ b/src/models/PostProps.ts
@@ -4,8 +4,8 @@ export type PostProps = {
   description: string;
   content: string;
   image: string;
-  author: string;
-  date: string;
+  author: { id: number; name: string; date: string };
+  createdAt: string;
   category: string;
   tags: string[];
   comments?: {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,10 +25,9 @@
     );
   }
 
-    
-    console.log(posts)
-    return (
-      <div className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
++    
++    return (
++      <div className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
       [&::-webkit-scrollbar]:hidden items-center justify-around rounded-lg w-[1200px]  h-[800px] blackBlue shadow-lg">
         <h1>Home</h1>
         <div className="grid grid-cols-3 gap-4">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,57 +1,57 @@
-import { useEffect, useState } from "react"
-import donnee from '../services/api/api.json'
-import { Link } from "react-router-dom"
 
-interface Data {
-  id: number,
-  title: string,
-  description: string,
-  image: string,
-  author: string,
-  date: string,
-  category: string,
-  tags: string[],
-  comments?: {
-    id: number,
-    author: string,
-    date: string,
-    content?: string
-  }[]
-}
-
-const Home = () => {
-  const [data, setData] = useState<Data[]>([])
+  // import donnee from '../services/api/api.json'
+  import { Link } from "react-router-dom"
+  // import { PostProps } from "../models/PostProps"
+  import { usePost } from "../hooks/usePost"
+  import usePostStore from "../store/postStore"
+  // import usePostStore from "../store/postStore"
 
 
-  useEffect(() => {
-    setData(donnee)
-  }, [])
-  console.log(data)
-  return (
-    <div className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
-     [&::-webkit-scrollbar]:hidden items-center justify-around rounded-lg w-[1200px]  h-[800px] blackBlue shadow-lg">
-      <h1>Home</h1>
-      <div className="grid grid-cols-3 gap-4">
-        {data.map((item) => (
-          <div key={item.id} className="flex flex-col items-center gap-2 p-2 bg-slate-50 border border-gray-800 rounded-lg">
-            <img src={item.image} alt={item.title} className="w-full h-52 rounded-sm" />
-            <h2 className="text-xl font-bold">{item.title}</h2>
-            {/* <p>{item.description}</p> */}
-            <p className="text-sm text-gray-500">By {item.author} on {item.date}</p>
-            <p className="text-sm text-gray-500">Category: {item.category}</p>
-            <div className="flex gap-2">
-              {item.tags.map((tag, index) => (
-                <span key={index} className="bg-blue-200 text-blue-800 px-2 py-1 rounded-full">#{tag}</span>
-              ))}
+
+  const Home = () => {
+    const {posts} = usePostStore()
+    const {handleGetPosts} = usePost()
+
+  // Handle loading and error states
+  if (handleGetPosts.isLoading) {
+    return <div>Loading posts...</div>;
+  }
+    
+  if (handleGetPosts.isError) {
+    return (
+      <div>
+        Error loading posts: {handleGetPosts.error?.message}
+      </div>
+    );
+  }
+
+    
+    console.log(posts)
+    return (
+      <div className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
+      [&::-webkit-scrollbar]:hidden items-center justify-around rounded-lg w-[1200px]  h-[800px] blackBlue shadow-lg">
+        <h1>Home</h1>
+        <div className="grid grid-cols-3 gap-4">
+          {posts.map((item) => (
+            <div key={item._id} className="flex flex-col items-center gap-2 p-2 bg-slate-50 border border-gray-800 rounded-lg">
+              <img src={item.image} alt={item.title} className="w-full h-52 rounded-sm" />
+              <h2 className="text-xl font-bold">{item.title}</h2>
+              {/* <p>{item.description}</p> */}
+              <p className="text-sm text-gray-500">By {item.author.name} on {new Date(item.createdAt).toLocaleString()}</p>
+              <p className="text-sm text-gray-500">Category: {item.category}</p>
+              <div className="flex gap-2">
+                {item.tags.map((tag, index) => (
+                  <span key={index} className="bg-blue-200 text-blue-800 px-2 py-1 rounded-full">#{tag}</span>
+                ))}
+              </div>
+              <div><Link to={`/item/${item._id}`} className="text-gray-500">Lire la suite</Link></div>
             </div>
-            <div><Link to={`/item/${item.id}`} className="text-gray-500">Lire la suite</Link></div>
+          ))}
           </div>
-        ))}
-        </div>
-      
-    </div>
-  )
-}
+        
+      </div>
+    )
+  }
 
-export default Home
+  export default Home
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,56 +1,67 @@
+// import donnee from '../services/api/api.json'
+import { Link } from "react-router-dom";
+// import { PostProps } from "../models/PostProps"
+import { usePost } from "../hooks/usePost";
+import usePostStore from "../store/postStore";
+// import usePostStore from "../store/postStore"
 
-  // import donnee from '../services/api/api.json'
-  import { Link } from "react-router-dom"
-  // import { PostProps } from "../models/PostProps"
-  import { usePost } from "../hooks/usePost"
-  import usePostStore from "../store/postStore"
-  // import usePostStore from "../store/postStore"
-
-
-
-  const Home = () => {
-    const {posts} = usePostStore()
-    const {handleGetPosts} = usePost()
+const Home = () => {
+  const { posts } = usePostStore();
+  const { handleGetPosts } = usePost();
 
   // Handle loading and error states
   if (handleGetPosts.isLoading) {
     return <div>Loading posts...</div>;
   }
-    
+
   if (handleGetPosts.isError) {
-    return (
-      <div>
-        Error loading posts: {handleGetPosts.error?.message}
-      </div>
-    );
+    return <div>Error loading posts: {handleGetPosts.error?.message}</div>;
   }
 
-+    
-+    return (
-+      <div className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
-      [&::-webkit-scrollbar]:hidden items-center justify-around rounded-lg w-[1200px]  h-[800px] blackBlue shadow-lg">
-        <h1>Home</h1>
-        <div className="grid grid-cols-3 gap-4">
-          {posts.map((item) => (
-            <div key={item._id} className="flex flex-col items-center gap-2 p-2 bg-slate-50 border border-gray-800 rounded-lg">
-              <img src={item.image} alt={item.title} className="w-full h-52 rounded-sm" />
-              <h2 className="text-xl font-bold">{item.title}</h2>
-              {/* <p>{item.description}</p> */}
-              <p className="text-sm text-gray-500">By {item.author.name} on {new Date(item.createdAt).toLocaleString()}</p>
-              <p className="text-sm text-gray-500">Category: {item.category}</p>
-              <div className="flex gap-2">
-                {item.tags.map((tag, index) => (
-                  <span key={index} className="bg-blue-200 text-blue-800 px-2 py-1 rounded-full">#{tag}</span>
-                ))}
-              </div>
-              <div><Link to={`/item/${item._id}`} className="text-gray-500">Lire la suite</Link></div>
+  return (
+    <div
+      className="container relative mx-28 p-1 flex flex-col overflow-y-scroll 
+      [&::-webkit-scrollbar]:hidden items-center justify-around rounded-lg w-[1200px]  h-[800px] blackBlue shadow-lg"
+    >
+      <h1>Home</h1>
+      <div className="grid grid-cols-3 gap-4">
+        {posts.map((item) => (
+          <div
+            key={item._id}
+            className="flex flex-col items-center gap-2 p-2 bg-slate-50 border border-gray-800 rounded-lg"
+          >
+            <img
+              src={item.image}
+              alt={item.title}
+              className="w-full h-52 rounded-sm"
+            />
+            <h2 className="text-xl font-bold">{item.title}</h2>
+            {/* <p>{item.description}</p> */}
+            <p className="text-sm text-gray-500">
+              By {item.author.name} on{" "}
+              {new Date(item.createdAt).toLocaleString()}
+            </p>
+            <p className="text-sm text-gray-500">Category: {item.category}</p>
+            <div className="flex gap-2">
+              {item.tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="bg-blue-200 text-blue-800 px-2 py-1 rounded-full"
+                >
+                  #{tag}
+                </span>
+              ))}
             </div>
-          ))}
+            <div>
+              <Link to={`/item/${item._id}`} className="text-gray-500">
+                Lire la suite
+              </Link>
+            </div>
           </div>
-        
+        ))}
       </div>
-    )
-  }
+    </div>
+  );
+};
 
-  export default Home
-
+export default Home;

--- a/src/pages/auth/components/ReadItems.tsx
+++ b/src/pages/auth/components/ReadItems.tsx
@@ -1,10 +1,11 @@
 import { NavLink, useParams } from "react-router-dom";
-import donnee from "../../../services/api/api.json";
 import { BiArrowToLeft } from "react-icons/bi";
+import usePostStore from "../../../store/postStore";
 
 const ReadItems = () => {
   const { id } = useParams<{ id: string }>();
-  const data = donnee.find((item) => item.id.toString() === id);
+  const { posts } = usePostStore();
+  const data = posts.find((item) => item._id.toString() === id);
 
   if (!data) {
     return <div>Item not found</div>;
@@ -33,8 +34,9 @@ const ReadItems = () => {
 
           <h2 className="text-xl font-bold">{data.title}</h2>
           <p>{data.description}</p>
+          <p>{data.content}</p>
           <p className="text-sm text-gray-500">
-            By {data.author} on {data.date}
+            By {data.author.name} on {data.createdAt}
           </p>
           <p className="text-sm text-gray-500">Category: {data.category}</p>
           <div className="flex gap-2">
@@ -54,3 +56,4 @@ const ReadItems = () => {
 };
 
 export default ReadItems;
+

--- a/src/pages/auth/components/ReadItems.tsx
+++ b/src/pages/auth/components/ReadItems.tsx
@@ -4,15 +4,26 @@ import usePostStore from "../../../store/postStore";
 
 const ReadItems = () => {
   const { id } = useParams<{ id: string }>();
-  const { posts } = usePostStore();
+  const { posts, isLoading, error } = usePostStore();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
   const data = posts.find((item) => item._id.toString() === id);
 
   if (!data) {
     return <div>Item not found</div>;
   }
 
+  const formattedDate = new Date(data.createdAt).toLocaleString();
+
   return (
-    <div className="container relative mx-auto my-6 p-1 flex flex-col overflow-y-scroll scrollbar [&::-webkit-scrollbar]:hidden items-start justify-around w-1/2 h-[800px] blackBlue">
+    <div className="container relative mx-auto my-6 p-1 flex flex-col overflow-y-scroll [&::-webkit-scrollbar]:hidden items-start justify-around w-1/2 h-[800px] blackBlue">
       <div className="flex flex-col gap-4">
         <button type="button" className="w-1/5 mt-1">
           <NavLink
@@ -23,7 +34,7 @@ const ReadItems = () => {
             Retour
           </NavLink>
         </button>
-        <div className="flex flex-col justify-center items-start gap-2 p-2 ">
+        <div className="flex flex-col justify-center items-start gap-2 p-2">
           <div className="w-full p-2 bg-slate-50 border border-gray-500 rounded-lg shadow-md">
             <img
               src={data.image}
@@ -36,7 +47,7 @@ const ReadItems = () => {
           <p>{data.description}</p>
           <p>{data.content}</p>
           <p className="text-sm text-gray-500">
-            By {data.author.name} on {data.createdAt}
+            By {data.author.name} on {formattedDate}
           </p>
           <p className="text-sm text-gray-500">Category: {data.category}</p>
           <div className="flex gap-2">

--- a/src/store/postStore.tsx
+++ b/src/store/postStore.tsx
@@ -17,7 +17,7 @@ type PostStore = {
 };
 
 const usePostStore = create<PostStore>((set) => ({
-  posts: [],
+  posts: [] as PostProps[],
   isLoading: false,
   error: null,
 

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+
+// Créer un client React Query
+const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 60 * 1000, // 5 minutes
+        gcTime: 10 * 60 * 1000, // 10 minutes
+        refetchOnWindowFocus: false,
+        retry: 1,
+      },
+    },
+  });
+
+export default queryClient;


### PR DESCRIPTION
use api service on home page and add queryProvider
```src/main.tsx
  ```

## Summary by Sourcery

Integrate React Query and Zustand to fetch posts from the API on the Home and ReadItems pages, replacing static JSON data and wiring in a QueryClientProvider.

New Features:
- Fetch posts via a custom usePost hook and Zustand store instead of local JSON
- Wrap the app in QueryClientProvider to enable React Query

Enhancements:
- Display loading and error states in Home and ReadItems components
- Update PostProps model to match API schema (author object and createdAt timestamp)

Chores:
- Add a queryClient utility with default React Query options
- Remove obsolete static imports and commented legacy code